### PR TITLE
Fix: Issue that tickets are not automated close at JIRA(v7.5.0).

### DIFF
--- a/lib/nexpose_ticketing/helpers/jira_helper.rb
+++ b/lib/nexpose_ticketing/helpers/jira_helper.rb
@@ -163,7 +163,7 @@ class JiraHelper < BaseHelper
 
     if transitions.has_key? 'transitions'
       transitions['transitions'].each do |transition|
-        if transition['to']['id'] == step_id.to_s
+        if transition['to']['statusCategory']['id'].to_s == step_id.to_s
           return transition
         end
       end


### PR DESCRIPTION
I fixed an issue that tickets are not automated close at JIRA(v7.5.0).

The cause is that JIRA's REST API response has changed.
http://<JIRA>/rest/api/2/issue/<Ticket ID>/transitions?expand=transitions.fields.